### PR TITLE
Only initialise session if HybridSession is enabled

### DIFF
--- a/src/Control/HybridSessionMiddleware.php
+++ b/src/Control/HybridSessionMiddleware.php
@@ -11,8 +11,10 @@ class HybridSessionMiddleware implements HTTPMiddleware
     public function process(HTTPRequest $request, callable $delegate)
     {
         try {
-            // Start session and execute
-            $request->getSession()->init($request);
+            if (HybridSession::is_enabled()) {
+                // Start session and execute
+                $request->getSession()->init($request);
+            }
 
             // Generate output
             $response = $delegate($request);


### PR DESCRIPTION
Only initialise session in the HybridSessionMiddleware, if HybridSession is actually enabled.

Currently it always initialises a session, although it is not actually uses.