### PR TITLE
Revert "Only initialise session if HybridSession is enabled"

### DIFF
--- a/src/Control/HybridSessionMiddleware.php
+++ b/src/Control/HybridSessionMiddleware.php
@@ -11,10 +11,8 @@ class HybridSessionMiddleware implements HTTPMiddleware
     public function process(HTTPRequest $request, callable $delegate)
     {
         try {
-            if (HybridSession::is_enabled()) {
-                // Start session and execute
-                $request->getSession()->init($request);
-            }
+            // Start session and execute
+            $request->getSession()->init($request);
 
             // Generate output
             $response = $delegate($request);


### PR DESCRIPTION
Reverts silverstripe/silverstripe-hybridsessions#42

This PR made the session only init if `HybridSession`s is enabled. Unfortunately this middleware is a replacement for the default session middleware:

https://github.com/silverstripe/silverstripe-hybridsessions/blob/c83a00b135278014014bf099372a5fba929a28fb/_config/sessions.yml#L12

This now breaks all environments that don't use hybrid sessions as the session is never started correctly.