### PR TITLE
Added data unset to stop data being read from outdated cookie

### DIFF
--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -138,7 +138,7 @@ class CookieStore extends BaseStore
             || !($crypto = $this->getCrypto($session_id))
         ) {
             if (strlen($session_data) > static::config()->get('max_length')) {
-                unset($this->currentCookieData);
+                $this->currentCookieData = null;
             }
 
             return false;

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -137,6 +137,10 @@ class CookieStore extends BaseStore
             || (strlen($session_data) > static::config()->get('max_length'))
             || !($crypto = $this->getCrypto($session_id))
         ) {
+            if (strlen($session_data) > static::config()->get('max_length')) {
+                unset($this->currentCookieData);
+            }
+
             return false;
         }
 

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -137,8 +137,18 @@ class CookieStore extends BaseStore
             || (strlen($session_data) > static::config()->get('max_length'))
             || !($crypto = $this->getCrypto($session_id))
         ) {
-            if (strlen($session_data) > static::config()->get('max_length')) {
+            if ($this->canWrite() && strlen($session_data) > static::config()->get('max_length')) {
                 $this->currentCookieData = null;
+                $params = session_get_cookie_params();
+                Cookie::set(
+                    $this->cookie,
+                    '',
+                    0,
+                    $params['path'],
+                    $params['domain'],
+                    $params['secure'],
+                    $params['httponly']
+                    );
             }
 
             return false;

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -148,7 +148,7 @@ class CookieStore extends BaseStore
                     $params['domain'],
                     $params['secure'],
                     $params['httponly']
-                    );
+                );
             }
 
             return false;

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -132,12 +132,13 @@ class CookieStore extends BaseStore
 
     public function write($session_id, $session_data)
     {
+        $canWrite = $this->canWrite();
+        $isExceedingCookieLimit = (strlen($session_data) > static::config()->get('max_length'));
+        $crypto = $this->getCrypto($session_id);
+
         // Check ability to safely encrypt and write content
-        if (!$this->canWrite()
-            || (strlen($session_data) > static::config()->get('max_length'))
-            || !($crypto = $this->getCrypto($session_id))
-        ) {
-            if ($this->canWrite() && strlen($session_data) > static::config()->get('max_length')) {
+        if (!$canWrite || $isExceedingCookieLimit || !$crypto) {
+            if ($canWrite && $isExceedingCookieLimit) {
                 $params = session_get_cookie_params();
                 // Clear stored cookie value and cookie when length exceeds the set limit
                 $this->currentCookieData = null;

--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -138,8 +138,9 @@ class CookieStore extends BaseStore
             || !($crypto = $this->getCrypto($session_id))
         ) {
             if ($this->canWrite() && strlen($session_data) > static::config()->get('max_length')) {
-                $this->currentCookieData = null;
                 $params = session_get_cookie_params();
+                // Clear stored cookie value and cookie when length exceeds the set limit
+                $this->currentCookieData = null;
                 Cookie::set(
                     $this->cookie,
                     '',


### PR DESCRIPTION
Fix for the case when the session increases in size and passes the cookie store limit (of currently 1024 characters).