### PR TITLE
Include specific versioned constraints in Travis builds rather than composer dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,22 @@ dist: trusty
 matrix:
   include:
     - php: 5.6
-      env: DB=MYSQL RECIPE_VERSION=1.0.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=1.0.x-dev VERSIONED=1.0.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
     - php: 7.0
-      env: DB=MYSQL RECIPE_VERSION=1.1.x-dev PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=1.1.x-dev VERSIONED=1.1.x-dev PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=MYSQL RECIPE_VERSION=4.2.x-dev PHPUNIT_COVERAGE_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.2.x-dev VERSIONED=1.2.x-dev PHPUNIT_COVERAGE_TEST=1
     - php: 7.2
-      env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev VERSIONED=1.3.x-dev PHPUNIT_TEST=1
+    - php: 7.3
+      env: DB=MYSQL RECIPE_VERSION=4.x-dev VERSIONED=1.x-dev PHPUNIT_TEST=1
 
 before_script:
   - phpenv rehash
   - phpenv config-rm xdebug.ini
   - echo 'memory_limit = 2G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer validate
-  - composer require silverstripe/recipe-core "$RECIPE_VERSION" --no-update
+  - composer require silverstripe/recipe-core:"$RECIPE_VERSION" silverstripe/versioned:"$VERSIONED" --no-update
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",
-        "squizlabs/php_codesniffer": "^3.0",
-        "silverstripe/versioned": "^1"
+        "squizlabs/php_codesniffer": "^3.0"
     },
     "extra": [],
     "autoload": {


### PR DESCRIPTION
Otherwise versioned ^1 installs 1.3 which contains incompatible APIs