### PR TITLE
DOCS Change "SilverStripe" to "Silverstripe" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Adds a session handler that tries storing the session in an encrypted cookie when possible, and if not (
 because the session is too large, or headers have already been set) stores it in the database.
 
-This allows using SilverStripe on multiple servers without sticky sessions (as long as you solve other
+This allows using Silverstripe on multiple servers without sticky sessions (as long as you solve other
 multi-server issues like asset storage and databases).
 
 ## Requirements


### PR DESCRIPTION
There was a relatively recent branding change from "SilverStripe" to "Silverstripe". This PR makes that change in the readme.

Note that the repository's description also still uses the old "SilverStripe" capitalisation.
![image](https://user-images.githubusercontent.com/36352093/150060531-19a76483-fa8f-494d-b117-1240a7553fd2.png)

See also silverstripe/silverstripe-framework#10206