### PR TITLE
FIX Return an emtpy string instead of false from HybridSession::read()

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ multi-server issues like asset storage and databases).
 
 ## Installation
 
-* Install with composer using `composer require silverstripe/hybridsessions:*`
+* Install with composer using `composer require silverstripe/hybridsessions`
 * /dev/build?flush=all to setup the necessary tables
 * In order to initiate the session handler is is necessary to add a snippet of code to your
   \_config.php, along with a private key used to encrypt user cookies.
 
-in `mysite/_config.php`
+in `app/src/_config.php`
 
 ```php
 // Ensure that you define a sufficiently indeterminable value for SS_SESSION_KEY in your `.env`

--- a/tests/HybridSessionTest.php
+++ b/tests/HybridSessionTest.php
@@ -53,7 +53,7 @@ class HybridSessionTest extends SapphireTest
     {
         $this->handler->expects($this->once())->method('read')->with('foosession')->willReturn(false);
         $this->instance->setHandlers([$this->handler]);
-        $this->assertFalse($this->instance->read('foosession'));
+        $this->assertSame('', $this->instance->read('foosession'));
     }
 
     public function testReadReturnsHandlerDelegateResult()


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-hybridsessions/issues/82

Reverts change from https://github.com/silverstripe/silverstripe-hybridsessions/pull/79/files#diff-ca4ddcb65cd9d12ea026a139173f0ece0c7ac066adb9b027c2f4f802bd42f936R78