### PR TITLE
FIX Always return something

### DIFF
--- a/src/Store/CookieStore.php
+++ b/src/Store/CookieStore.php
@@ -110,6 +110,8 @@ class CookieStore extends BaseStore
                 return $data;
             }
         }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-hybridsessions/issues/85

Fixes:
`error-log.ERROR: Uncaught Exception TypeError: "SilverStripe\HybridSessions\Store\CookieStore::read(): Return value must be of type string|false, none returned" at /sites/somesite/releases/somerelease/vendor/silverstripe/hybridsessions/src/Store/CookieStore.php line 113 {"exception":"[object] (TypeError(code: 0): SilverStripe\\HybridSessions\\Store\\CookieStore::read(): Return value must be of type string|false, none returned at /sites/somesite/releases/somerelease/vendor/silverstripe/hybridsessions/src/Store/CookieStore.php:113)"} []`