### PR TITLE
MNT Require phpunit ^9.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "silverstripe/framework": "^5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "squizlabs/php_codesniffer": "^3",
         "silverstripe/versioned": "^2"
     },


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/34

Fixes --prefer-lowest build - https://github.com/silverstripe/silverstripe-hybridsessions/actions/runs/4559193473/jobs/8042962237#step:12:68

`1) SilverStripe\HybridSessions\Tests\HybridSessionTest::testReadReturnsEmptyStringWithNoHandlers
PHPUnit\Framework\MockObject\IncompatibleReturnValueException: Method read may not return value of type boolean, its return declaration is "false|string"`
