### PR TITLE
FIX Prevent openssl_decrypt warning when IV length is incorrect

### DIFF
--- a/src/Crypto/OpenSSLCrypto.php
+++ b/src/Crypto/OpenSSLCrypto.php
@@ -91,6 +91,12 @@ class OpenSSLCrypto implements CryptoHandler
         $iv = substr($c ?? '', 0, $ivlen);
         $hmac = substr($c ?? '', $ivlen ?? 0, $sha2len = 32);
         $ciphertext_raw = substr($c ?? '', $ivlen + $sha2len);
+
+        // Only attempt decryption if IV is long enough
+        if (strlen($iv) !== $ivlen) {
+            return false;
+        }
+
         $cleartext = openssl_decrypt(
             $ciphertext_raw ?? '',
             $cipher ?? '',


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->

## Description

This PR fixes a PHP warning logged when decrypting session data, specifically:  
`E_WARNING: openssl_decrypt(): IV passed is only X bytes long, cipher expects an IV of precisely 16 bytes, padding with \0`

This happened when a malformed or corrupted session cookie was provided to `OpenSSLCrypto->decrypt()`, resulting in an IV of insufficient length for the AES-256-CBC cipher. The new logic ensures the IV used is always the correct length, preventing the warning.

### Code changes

```php
// Only attempt decryption if IV is long enough
if (strlen($iv) !== $ivlen) {
    return false;
}
```

Now, if the IV extracted from the cookie is not the required 16 bytes, decryption is skipped and `false` is returned, avoiding noise in logs and handling invalid/corrupt cookies gracefully.

## Manual testing steps

1. With this branch checked out, run the following PHP code in your project context:
    ```php
    $crypto = new SilverStripe\HybridSessions\Crypto\OpenSSLCrypto('key', 'salt');
    $data = base64_encode('zxc'); // Deliberately short input
    $crypto->decrypt($data); // Should no longer emit a warning, and returns false
    ```
2. Confirm that no warning about IV length is emitted.
3. Test normal session operations (login, logout, persistence) to ensure still working as expected.
4. Optionally, run unit tests to confirm there are no regressions.

## Issues

- Closes https://github.com/silverstripe/silverstripe-hybridsessions/issues/69

## Pull request checklist

- [x] The target branch is correct ([see docs](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version))
- [x] All commits are relevant to the purpose of the PR (no unrelated changes)
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant documentation is updated; changelog entries created for user-impacting changes
- [x] CI is green (will be checked after push)